### PR TITLE
Support custom fisher path

### DIFF
--- a/conf.d/kubectl.fish
+++ b/conf.d/kubectl.fish
@@ -4,7 +4,7 @@ functions -e _kubectl_uninstall
 
 # fisher initialization, protected as omf also tries to run it.
 set -q fisher_path; or set -l fisher_path $__fish_config_dir
-if test -f $__fish_config_dir/functions/__kubectl.init.fish
-  source $__fish_config_dir/functions/__kubectl.init.fish
+if test -f $fisher_path/functions/__kubectl.init.fish
+  source $fisher_path/functions/__kubectl.init.fish
   __kubectl.init
 end


### PR DESCRIPTION
`fisher_path` is set, but not used, so the plugin does not work when fisher is configured to install plugins into non-default directory.